### PR TITLE
Update README and pulpcore.te

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,22 @@ The SELinux policy for Pulp 3.Y releases.
 ## Building
 
 ```
-sudo yum install -y selinux-policy-devel  policycoreutils-python
+sudo yum install -y selinux-policy-devel  policycoreutils
 git clone https://github.com/pulp/pulpcore-selinux
 cd pulpcore-selinux
 
-make  # this performs the building
+make -f /usr/share/selinux/devel/Makefile pulp_port.pp
+make -f /usr/share/selinux/devel/Makefile pulpcore.pp
 ```
 
 ## Installing
 
-`sudo make install-policy`
+```
+semodule -i pulp_port.pp
+semodule -i pulpcore.pp
+```
 
-## Labeling pulp_port
+## Labeling pulp\_port
 
 **Required**: You must label your ports with `pulp_port_t` or SELinux won't allow Pulp to
 communicate on with the network correctly.

--- a/pulpcore.te
+++ b/pulpcore.te
@@ -60,7 +60,7 @@ fs_getattr_xattr_fs(pulpcore_t)
 
 libs_exec_ldconfig(pulpcore_t)
 
-miscfiles_read_certs(pulpcore_t)
+miscfiles_read_generic_certs(pulpcore_t)
 
 sysnet_read_config(pulpcore_t)
 


### PR DESCRIPTION
Changed building and installing steps in README:
- Pulp_port module has to be installed first, except for Fedora 31 and Fedora Rawhide in which pulp_port type is included in the base SELinux policy.
- The SELinux policy for Pulp was this way successfully installed on Fedora 30, Fedora 31, Fedora Rawhide, RHEL 7.5, RHEL 7.8, RHEL 8.0, RHEL 8.1 and RHEL 8.2 Beta.

Update pulpcore.te file:
- miscfiles_read_certs() replaced by miscfiles_read_generic_certs(), because miscfiles_read_certs() has been deprecated.

Fixed: https://pulp.plan.io/issues/6048