### PR TITLE
Lists all directories inside /var/lib/pulp/ that are used by pulpcore

### DIFF
--- a/pulpcore.fc
+++ b/pulpcore.fc
@@ -4,7 +4,10 @@
 /usr/local/lib/pulp/bin/gunicorn		--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
 /usr/local/lib/pulp/bin/rq		--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
 
-/var/lib/pulp(/.*)? 	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
+/var/lib/pulp/artifact(/.*)? 	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
+/var/lib/pulp/assets(/.*)? 	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
+/var/lib/pulp/tmp(/.*)? 	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
+/var/lib/pulp/upload(/.*)? 	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
 
 /var/run/pulpcore*(/.*)? 	gen_context(system_u:object_r:pulpcore_var_run_t,s0)
 /var/run/pulpcore-api(/.*)? 	gen_context(system_u:object_r:pulpcore_var_run_t,s0)


### PR DESCRIPTION
This avoids having a conflict with the pulp-server 2.y.z SELinux policy which states:

    /var/lib/pulp(/.*)? gen_context(system_u:object_r:httpd_sys_rw_content_t,s0)

re: #5995
https://pulp.plan.io/issues/5995