### PR TITLE
Use libexec wrappers

### DIFF
--- a/pulpcore.fc
+++ b/pulpcore.fc
@@ -12,6 +12,7 @@
 /usr/bin/gunicorn	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
 
 /usr/libexec/pulpcore/.*	--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
+/usr/libexec/pulpcore/gunicorn	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
 
 /usr/lib/pulp/bin/gunicorn	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
 /usr/lib/pulp/bin/rq		--	gen_context(system_u:object_r:pulpcore_exec_t,s0)

--- a/pulpcore.fc
+++ b/pulpcore.fc
@@ -14,9 +14,6 @@
 /usr/libexec/pulpcore/.*	--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
 /usr/libexec/pulpcore/gunicorn	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
 
-/usr/lib/pulp/bin/gunicorn	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
-/usr/lib/pulp/bin/rq		--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
-
 /usr/local/lib/pulp/bin/gunicorn	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
 /usr/local/lib/pulp/bin/rq		--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
 


### PR DESCRIPTION
Since the locations of gunicorn and rq can differ, this starts to promote wrappers in libexec. This is also needed for RPM packaging where the files are in /usr/bin using the system wide interpreter. Other tools may be using those same files.

This is a draft so I can refer to it in my patches. It is ready for feedback, but I haven't tested this yet.

Open question: should the old bins be removed and only libexec?