### PR TITLE
Major updates to the pulpcore policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ cd pulpcore-selinux
 
 make -f /usr/share/selinux/devel/Makefile pulpcore_port.pp
 make -f /usr/share/selinux/devel/Makefile pulpcore.pp
+make -f /usr/share/selinux/devel/Makefile pulpcore_rhsmcertd.pp
 ```
 
 ## Installing
@@ -18,14 +19,14 @@ make -f /usr/share/selinux/devel/Makefile pulpcore.pp
 ```
 semodule -i pulpcore_port.pp
 semodule -i pulpcore.pp
+semodule -i pulpcore_rhsmcertd.pp
 ```
 
 ## Labeling pulpcore\_port
 
-**Required**: You must label your ports with `pulpcore_port_t` or SELinux won't allow Pulp to
-communicate on with the network correctly.
+**Required**: You must label ports used by Pulp with `pulpcore_port_t` so that the proper type is assigned to the ports and Pulp is allowed to communicate on with the network correctly.
 
-Apply the `pulpcore_port_t` SELinux label to ports 24816 and 24817 with:
+Apply the `pulpcore_port_t` SELinux type to ports 24816 and 24817 with:
 
 `semanage port -a -t pulpcore_port_t -p tcp 24816-24817`
 
@@ -35,6 +36,8 @@ Apply the `pulpcore_port_t` SELinux label to ports 24816 and 24817 with:
 Uninstall in the following order:
 
 ```
+semanage port -d -t pulpcore_port_t -p tcp 24816-24817
+semodule -r pulpcore_rhsmcertd
 semodule -r pulpcore
 semodule -r pulpcore_port
 ```

--- a/pulpcore.fc
+++ b/pulpcore.fc
@@ -1,16 +1,20 @@
-/usr/lib/pulp/bin/gunicorn		--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
+/usr/bin/rq		--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
+/usr/bin/gunicorn	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
+
+/usr/libexec/pulpcore/.*	--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
+
+/usr/lib/pulp/bin/gunicorn	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
 /usr/lib/pulp/bin/rq		--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
 
-/usr/local/lib/pulp/bin/gunicorn		--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
+/usr/local/lib/pulp/bin/gunicorn	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
 /usr/local/lib/pulp/bin/rq		--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
 
 /var/lib/pulp/artifact(/.*)? 	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
 /var/lib/pulp/assets(/.*)? 	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
+/var/lib/pulp/devel(/.*)? 	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
 /var/lib/pulp/tmp(/.*)? 	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
 /var/lib/pulp/upload(/.*)? 	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
+/var/lib/pulp/sign-metadata.sh	--	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
 
-/var/run/pulpcore*(/.*)? 	gen_context(system_u:object_r:pulpcore_var_run_t,s0)
-/var/run/pulpcore-api(/.*)? 	gen_context(system_u:object_r:pulpcore_var_run_t,s0)
-/var/run/pulpcore-content(/.*)? 	gen_context(system_u:object_r:pulpcore_var_run_t,s0)
-/var/run/pulpcore-resource-manager(/.*)? 	gen_context(system_u:object_r:pulpcore_var_run_t,s0)
-/var/run/pulpcore-resource-worker[0-9]*(/.*)? 	gen_context(system_u:object_r:pulpcore_var_run_t,s0)
+/var/run/pulpcore-content(/.*)? 	gen_context(system_u:object_r:pulpcore_server_var_run_t,s0)
+/var/run/pulpcore.*		 	gen_context(system_u:object_r:pulpcore_var_run_t,s0)

--- a/pulpcore.if
+++ b/pulpcore.if
@@ -1,4 +1,29 @@
 ## <summary>Platform for managing repositories of software packages</summary>
+#
+#########################################
+## <summary>
+##	Transition to pulpcore named content
+## </summary>
+## <param name="domain">
+##	<summary>
+##      Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pulpcore_filetrans_named_content',`
+	gen_require(`
+		type pulpcore_var_run_t, pulpcore_server_var_run_t;
+	')
+
+	files_pid_filetrans($1, pulpcore_server_var_run_t, { dir }, "pulpcore-content")
+	files_pid_filetrans($1, pulpcore_var_run_t, { dir }, "pulpcore-api")
+	files_pid_filetrans($1, pulpcore_var_run_t, { dir }, "resource-manager")
+	files_pid_filetrans($1, pulpcore_var_run_t, { dir }, "resource-worker-0")
+	files_pid_filetrans($1, pulpcore_var_run_t, { dir }, "resource-worker-1")
+')
+
+########################################
+
 
 ########################################
 ## <summary>
@@ -17,6 +42,27 @@ interface(`corenet_tcp_bind_pulpcore_port',`
 	')
 
 	allow $1 pulpcore_port_t:tcp_socket name_bind;
+
+')
+
+
+########################################
+## <summary>
+##	Connect TCP sockets to the pulp port.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <infoflow type="none"/>
+#
+interface(`corenet_tcp_connect_pulpcore_port',`
+	gen_require(`
+		type pulpcore_port_t;
+	')
+
+	allow $1 pulpcore_port_t:tcp_socket name_connect;
 	
 ')
 

--- a/pulpcore.te
+++ b/pulpcore.te
@@ -9,58 +9,130 @@ type pulpcore_t;
 type pulpcore_exec_t;
 init_daemon_domain(pulpcore_t, pulpcore_exec_t)
 init_nnp_daemon_domain(pulpcore_t)
+permissive pulpcore_t;
+
+type pulpcore_server_t;
+type pulpcore_server_exec_t;
+init_daemon_domain(pulpcore_server_t, pulpcore_server_exec_t)
+init_nnp_daemon_domain(pulpcore_server_t)
+permissive pulpcore_server_t;
 
 type pulpcore_var_lib_t;
 files_type(pulpcore_var_lib_t)
+type pulpcore_server_var_lib_t;
+files_type(pulpcore_server_var_lib_t)
 
 type pulpcore_var_run_t;
 files_pid_file(pulpcore_var_run_t)
+type pulpcore_server_var_run_t;
+files_pid_file(pulpcore_server_var_run_t)
 
 type pulpcore_tmp_t;
 files_tmp_file(pulpcore_tmp_t)
+type pulpcore_server_tmp_t;
+files_tmp_file(pulpcore_server_tmp_t)
+
+type pulpcore_server_tmpfs_t;
+files_tmpfs_file(pulpcore_server_tmpfs_t);
 
 ########################################
 #
-# pulpcore_api local policy
+# pulpcore/pulpcore_server local policy
 #
-allow pulpcore_t self:fifo_file rw_fifo_file_perms;
-allow pulpcore_t self:unix_stream_socket create_stream_socket_perms;
-allow pulpcore_t self:netlink_route_socket { create_socket_perms nlmsg_read };
-allow pulpcore_t self:tcp_socket create_stream_socket_perms;
-allow pulpcore_t self:udp_socket create_stream_socket_perms;
+allow pulpcore_t pulpcore_server_exec_t:file getattr;
+allow pulpcore_server_t pulpcore_exec_t:file getattr;
 
+allow pulpcore_server_t self:fifo_file rw_fifo_file_perms;
+allow pulpcore_server_t self:unix_stream_socket create_stream_socket_perms;
+allow pulpcore_server_t self:netlink_route_socket { create_socket_perms nlmsg_read };
+allow pulpcore_server_t self:tcp_socket create_stream_socket_perms;
+allow pulpcore_server_t self:udp_socket create_stream_socket_perms;
+
+# /etc
+read_files_pattern(pulpcore_t, pulpcore_etc_t, pulpcore_etc_t)
+read_files_pattern(pulpcore_server_t, pulpcore_etc_t, pulpcore_etc_t)
+
+# /var/lib
 manage_dirs_pattern(pulpcore_t, pulpcore_var_lib_t, pulpcore_var_lib_t)
 manage_files_pattern(pulpcore_t, pulpcore_var_lib_t, pulpcore_var_lib_t)
-relabel_files_pattern(pulpcore_t, pulpcore_var_lib_t, pulpcore_var_lib_t)
-manage_lnk_files_pattern(pulpcore_t, pulpcore_var_lib_t, pulpcore_var_lib_t)
-files_var_lib_filetrans(pulpcore_t, pulpcore_var_lib_t, { dir file })
 
+manage_dirs_pattern(pulpcore_server_t, pulpcore_server_var_lib_t, pulpcore_server_var_lib_t)
+manage_files_pattern(pulpcore_server_t, pulpcore_server_var_lib_t, pulpcore_server_var_lib_t)
+ 
+manage_dirs_pattern(pulpcore_t, pulpcore_server_var_lib_t, pulpcore_server_var_lib_t)
+manage_files_pattern(pulpcore_t, pulpcore_server_var_lib_t, pulpcore_server_var_lib_t)
+
+filetrans_pattern(pulpcore_server_t, pulpcore_var_lib_t, pulpcore_server_var_lib_t, { dir file })
+manage_dirs_pattern(pulpcore_server_t, pulpcore_var_lib_t, pulpcore_var_lib_t)
+manage_files_pattern(pulpcore_server_t, pulpcore_var_lib_t, pulpcore_var_lib_t)
+read_lnk_files_pattern(pulpcore_server_t, pulpcore_var_lib_t, pulpcore_var_lib_t)
+write_sock_files_pattern(pulpcore_t, pulpcore_var_lib_t, pulpcore_var_lib_t)
+
+# /run
 manage_dirs_pattern(pulpcore_t, pulpcore_var_run_t, pulpcore_var_run_t)
 manage_files_pattern(pulpcore_t, pulpcore_var_run_t, pulpcore_var_run_t)
-files_pid_filetrans(pulpcore_t, pulpcore_var_run_t, { dir })
+files_pid_filetrans(pulpcore_t, pulpcore_var_run_t, { file dir })
 
+manage_dirs_pattern(pulpcore_server_t, pulpcore_server_var_run_t, pulpcore_server_var_run_t)
+manage_files_pattern(pulpcore_server_t, pulpcore_server_var_run_t, pulpcore_server_var_run_t)
+files_pid_filetrans(pulpcore_server_t, pulpcore_server_var_run_t, { file dir })
+
+# /tmp
 manage_dirs_pattern(pulpcore_t, pulpcore_tmp_t, pulpcore_tmp_t)
 manage_files_pattern(pulpcore_t, pulpcore_tmp_t, pulpcore_tmp_t)
-relabel_files_pattern(pulpcore_t, pulpcore_tmp_t, pulpcore_tmp_t)
+manage_lnk_files_pattern(pulpcore_t, pulpcore_tmp_t, pulpcore_tmp_t)
 files_tmp_filetrans(pulpcore_t, pulpcore_tmp_t, { file dir })
 
+manage_dirs_pattern(pulpcore_server_t, pulpcore_server_tmp_t, pulpcore_server_tmp_t)
+manage_files_pattern(pulpcore_server_t, pulpcore_server_tmp_t, pulpcore_server_tmp_t)
+files_tmp_filetrans(pulpcore_server_t, pulpcore_server_tmp_t, { file dir })
+
+# /dev/shm
+manage_files_pattern(pulpcore_t, pulpcore_server_tmpfs_t, pulpcore_server_tmpfs_t)
+fs_tmpfs_filetrans(pulpcore_t, pulpcore_server_tmpfs_t, file )
+allow pulpcore_t pulpcore_server_tmpfs_t:file map;
+
+# interface calls
+auth_use_nsswitch(pulpcore_server_t)
 auth_use_nsswitch(pulpcore_t)
+
+can_exec(pulpcore_t, pulpcore_var_lib_t)
 
 corecmd_exec_bin(pulpcore_t)
 corecmd_exec_shell(pulpcore_t)
+corecmd_exec_bin(pulpcore_server_t)
+corecmd_exec_shell(pulpcore_server_t)
 
-corenet_tcp_bind_pulpcore_port(pulpcore_t)
-corenet_tcp_connect_postgresql_port(pulpcore_t)
-corenet_tcp_connect_redis_port(pulpcore_t)
 corenet_tcp_connect_http_port(pulpcore_t)
+corenet_tcp_connect_postgresql_port(pulpcore_t)
+corenet_tcp_connect_pulpcore_port(pulpcore_t)
+corenet_tcp_connect_redis_port(pulpcore_t)
+corenet_tcp_bind_pulpcore_port(pulpcore_server_t)
+corenet_tcp_connect_http_port(pulpcore_server_t)
+corenet_tcp_connect_postgresql_port(pulpcore_server_t)
+corenet_tcp_connect_redis_port(pulpcore_server_t)
 
-fs_read_fusefs_files(pulpcore_t)
-fs_read_fusefs_symlinks(pulpcore_t)
+fs_getattr_tmpfs(pulpcore_t)
 fs_getattr_xattr_fs(pulpcore_t)
+fs_getattr_xattr_fs(pulpcore_server_t)
 
 libs_exec_ldconfig(pulpcore_t)
+libs_exec_ldconfig(pulpcore_server_t)
 
 miscfiles_read_generic_certs(pulpcore_t)
 
 sysnet_read_config(pulpcore_t)
+
+optional_policy(`
+        gpg_exec(pulpcore_t)
+')
+
+optional_policy(`
+	kerberos_read_keytab(pulpcore_t)
+	kerberos_read_keytab(pulpcore_server_t)
+')
+
+optional_policy(`
+	unconfined_stream_connect(pulpcore_t)
+')
 

--- a/pulpcore_rhsmcertd.te
+++ b/pulpcore_rhsmcertd.te
@@ -1,0 +1,8 @@
+policy_module(pulpcore_rhsmcertd, 1.0)
+
+gen_require(`
+	type pulpcore_server_t, rhsmcertd_config_t;
+')
+
+allow pulpcore_server_t rhsmcertd_config_t:dir search_dir_perms;
+allow pulpcore_server_t rhsmcertd_config_t:file read_file_perms;

--- a/pulpcore_semanage_port.txt
+++ b/pulpcore_semanage_port.txt
@@ -1,0 +1,1 @@
+semanage port -a -t pulpcore_port_t -p tcp 24816-24817


### PR DESCRIPTION
Support for RHEL 8.
Support for ansible.
Different types for client and server domains, together with separate
private types for /run, /tmp, /var/lib.
Support for multiple paths for the same executable.