### PR TITLE
Problem: pulpcore-selinux fails to build due to unknown type pulpcore…

### DIFF
--- a/pulpcore.fc
+++ b/pulpcore.fc
@@ -1,3 +1,12 @@
+#/etc/pulp/certs(/.*)?			gen_context(system_u:object_r:pulpcore_etc_t,s0)
+/etc/pulp/settings.py			gen_context(system_u:object_r:pulpcore_etc_t,s0)
+/etc/pulp/token_private_key.pem			gen_context(system_u:object_r:pulpcore_etc_t,s0)
+/etc/pulp/token_public_key.pem			gen_context(system_u:object_r:pulpcore_etc_t,s0)
+# The installer prior to 2020-08-20 used these 2 token paths. Clean up once dev
+# instance is deleted.
+/etc/pulp/private_key.pem			gen_context(system_u:object_r:pulpcore_etc_t,s0)
+/etc/pulp/public_key.pem			gen_context(system_u:object_r:pulpcore_etc_t,s0)
+
 /usr/bin/rq		--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
 /usr/bin/gunicorn	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
 

--- a/pulpcore.fc
+++ b/pulpcore.fc
@@ -1,4 +1,5 @@
-#/etc/pulp/certs(/.*)?			gen_context(system_u:object_r:pulpcore_etc_t,s0)
+# label for both nginx & apache
+/etc/pulp/certs(/.*)?			gen_context(system_u:object_r:httpd_config_t,s0)
 /etc/pulp/settings.py			gen_context(system_u:object_r:pulpcore_etc_t,s0)
 /etc/pulp/token_private_key.pem			gen_context(system_u:object_r:pulpcore_etc_t,s0)
 /etc/pulp/token_public_key.pem			gen_context(system_u:object_r:pulpcore_etc_t,s0)

--- a/pulpcore.te
+++ b/pulpcore.te
@@ -17,6 +17,9 @@ init_daemon_domain(pulpcore_server_t, pulpcore_server_exec_t)
 init_nnp_daemon_domain(pulpcore_server_t)
 permissive pulpcore_server_t;
 
+type pulpcore_etc_t;
+files_config_file(pulpcore_etc_t)
+
 type pulpcore_var_lib_t;
 files_type(pulpcore_var_lib_t)
 type pulpcore_server_var_lib_t;


### PR DESCRIPTION
…_etc_t

Solution: Label the /etc/pulp/ files and subfolders individually
(And declare the type to fix the failure.)

fixes: #7532