### PR TITLE
pulpcore-selinux version disagrees with tag

### DIFF
--- a/pulpcore.te
+++ b/pulpcore.te
@@ -1,4 +1,4 @@
-policy_module(pulpcore, 1.0.0)
+policy_module(pulpcore, 1.1.1)
 
 ########################################
 #

--- a/pulpcore_port.te
+++ b/pulpcore_port.te
@@ -1,4 +1,4 @@
-policy_module(pulpcore_port, 1.0)
+policy_module(pulpcore_port, 1.1.1)
 
 gen_require(`
     attribute port_type;

--- a/pulpcore_rhsmcertd.te
+++ b/pulpcore_rhsmcertd.te
@@ -1,4 +1,4 @@
-policy_module(pulpcore_rhsmcertd, 1.0)
+policy_module(pulpcore_rhsmcertd, 1.1.1)
 
 gen_require(`
 	type pulpcore_server_t, rhsmcertd_config_t;


### PR DESCRIPTION
Solution: Bump the version in the policies from 1.0 / 1.0.0
to 1.1.1, the next release.

fixes: #7617
https://pulp.plan.io/issues/7617
pulpcore-selinux version disagrees with tag
