### PR TITLE
pulpcore_var_lib_t: Label all the things under /var/lib/pulp

### DIFF
--- a/pulpcore.fc
+++ b/pulpcore.fc
@@ -20,6 +20,7 @@
 /var/lib/pulp/artifact(/.*)? 	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
 /var/lib/pulp/assets(/.*)? 	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
 /var/lib/pulp/devel(/.*)? 	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
+/var/lib/pulp/pulpcore_static(/.*)? 	gen_context(system_u:object_r:httpd_sys_content_t,s0)
 /var/lib/pulp/tmp(/.*)? 	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
 /var/lib/pulp/upload(/.*)? 	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
 /var/lib/pulp/sign-metadata.sh	--	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)


### PR DESCRIPTION
Current label applied to /var/lib/pulp seems incosistent/erroneous

```
[root@localhost vagrant]# ls -lZ /var/lib | grep pulp
drwx-----x. pulp pulp unconfined_u:object_r:var_lib_t:s0 pulp

[root@localhost vagrant]# ls -lZ /var/lib/pulp/
drwxr-xr-x. pulp pulp unconfined_u:object_r:pulpcore_var_lib_t:s0 assets
drwxr-xr-x. pulp pulp unconfined_u:object_r:var_lib_t:s0 pulpcore_static
drwxrwxr-x. pulp pulp unconfined_u:object_r:pulpcore_var_lib_t:s0 tmp
```

Not how /var/lib/pulp and /var/lib/pulp/puplcore_static are wrongly
labelled. A restorecon didn't/wouldn't help as they are not part of the
fc file.