### PR TITLE
Drop old gunicorn and rq paths

### DIFF
--- a/pulpcore.fc
+++ b/pulpcore.fc
@@ -8,9 +8,6 @@
 /etc/pulp/private_key.pem			gen_context(system_u:object_r:pulpcore_etc_t,s0)
 /etc/pulp/public_key.pem			gen_context(system_u:object_r:pulpcore_etc_t,s0)
 
-/usr/bin/rq		--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
-/usr/bin/gunicorn	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
-
 /usr/libexec/pulpcore/.*	--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
 /usr/libexec/pulpcore/gunicorn	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
 


### PR DESCRIPTION
Since cc53e5c1ae8b87d0fb449dd8c42e8dc2841730bb the proper way to use gunicorn and rq is via /usr/libexec/pulpcore. This also matches the pulpcore-selinux package which only relabels python3-pulpcore.

Both installers have been modified so /usr/bin/{rq,gunicorn} can be dropped.

System packages should not touch anything in /usr/local so the paths should also be dropped. If anyone wants to depart from system packages and install to /usr/local, it's up to them to properly label paths. They can also place wrappers in `/usr/libexec/pulpcore`.