### PR TITLE
Set the correct SELinux type also for runtime socket files

### DIFF
--- a/pulpcore.fc
+++ b/pulpcore.fc
@@ -21,5 +21,6 @@
 /var/lib/pulp/upload(/.*)?	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
 /var/lib/pulp/sign-metadata.sh	--	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
 
+/var/run/pulpcore-api(/.*)?		gen_context(system_u:object_r:pulpcore_server_var_run_t,s0)
 /var/run/pulpcore-content(/.*)?		gen_context(system_u:object_r:pulpcore_server_var_run_t,s0)
 /var/run/pulpcore.*			gen_context(system_u:object_r:pulpcore_var_run_t,s0)

--- a/pulpcore.if
+++ b/pulpcore.if
@@ -16,10 +16,30 @@ interface(`pulpcore_filetrans_named_content',`
 	')
 
 	files_pid_filetrans($1, pulpcore_server_var_run_t, { dir }, "pulpcore-content")
-	files_pid_filetrans($1, pulpcore_var_run_t, { dir }, "pulpcore-api")
-	files_pid_filetrans($1, pulpcore_var_run_t, { dir }, "resource-manager")
-	files_pid_filetrans($1, pulpcore_var_run_t, { dir }, "resource-worker-0")
-	files_pid_filetrans($1, pulpcore_var_run_t, { dir }, "resource-worker-1")
+	files_pid_filetrans($1, pulpcore_server_var_run_t, { dir }, "pulpcore-api")
+	files_pid_filetrans($1, pulpcore_var_run_t, { dir }, "pulpcore-resource-manager")
+	files_pid_filetrans($1, pulpcore_var_run_t, { dir }, "pulpcore-worker-1")
+	files_pid_filetrans($1, pulpcore_var_run_t, { dir }, "pulpcore-worker-2")
+')
+
+
+#######################################
+## <summary>
+##	Connect to pulpcore-server over a unix domain stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pulpcore_server_stream_connect',`
+	gen_require(`
+		type pulpcore_server_t, pulpcore_server_var_run_t;
+	')
+
+	files_search_pids($1)
+	stream_connect_pattern($1, pulpcore_server_var_run_t, pulpcore_server_var_run_t, pulpcore_server_t)
 ')
 
 ########################################
@@ -66,3 +86,21 @@ interface(`corenet_tcp_connect_pulpcore_port',`
 	
 ')
 
+#######################################
+## <summary>
+##	Connect to redis over a unix domain stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`redis_stream_connect',`
+	gen_require(`
+		type redis_t, redis_var_run_t;
+	')
+
+	files_search_pids($1)
+	stream_connect_pattern($1, redis_var_run_t, redis_var_run_t, redis_t)
+')

--- a/pulpcore.te
+++ b/pulpcore.te
@@ -74,11 +74,12 @@ write_sock_files_pattern(pulpcore_t, pulpcore_var_lib_t, pulpcore_var_lib_t)
 # /run
 manage_dirs_pattern(pulpcore_t, pulpcore_var_run_t, pulpcore_var_run_t)
 manage_files_pattern(pulpcore_t, pulpcore_var_run_t, pulpcore_var_run_t)
-files_pid_filetrans(pulpcore_t, pulpcore_var_run_t, { file dir })
+files_pid_filetrans(pulpcore_t, pulpcore_var_run_t, { dir file sock_file})
 
 manage_dirs_pattern(pulpcore_server_t, pulpcore_server_var_run_t, pulpcore_server_var_run_t)
 manage_files_pattern(pulpcore_server_t, pulpcore_server_var_run_t, pulpcore_server_var_run_t)
-files_pid_filetrans(pulpcore_server_t, pulpcore_server_var_run_t, { file dir })
+manage_sock_files_pattern(pulpcore_server_t, pulpcore_server_var_run_t, pulpcore_server_var_run_t)
+files_pid_filetrans(pulpcore_server_t, pulpcore_server_var_run_t, { dir file sock_file})
 
 # /tmp
 manage_dirs_pattern(pulpcore_t, pulpcore_tmp_t, pulpcore_tmp_t)
@@ -96,6 +97,9 @@ fs_tmpfs_filetrans(pulpcore_t, pulpcore_server_tmpfs_t, file )
 allow pulpcore_t pulpcore_server_tmpfs_t:file map;
 
 # interface calls
+kernel_read_all_proc(pulpcore_t)
+kernel_read_all_proc(pulpcore_server_t)
+
 auth_use_nsswitch(pulpcore_server_t)
 auth_use_nsswitch(pulpcore_t)
 
@@ -136,6 +140,36 @@ optional_policy(`
 ')
 
 optional_policy(`
+	postgresql_stream_connect(pulpcore_t)
+	postgresql_stream_connect(pulpcore_server_t)
+')
+
+optional_policy(`
+	redis_stream_connect(pulpcore_t)
+	redis_stream_connect(pulpcore_server_t)
+')
+
+optional_policy(`
 	unconfined_stream_connect(pulpcore_t)
 ')
 
+########################################
+#
+# Local policy for external domains
+#
+
+optional_policy(`
+	gen_require(`
+		type httpd_t;
+	')
+
+	pulpcore_server_stream_connect(httpd_t)
+')
+
+optional_policy(`
+	gen_require(`
+		type init_t;
+	')
+
+	pulpcore_filetrans_named_content(init_t)
+')


### PR DESCRIPTION
In the runtime directory, file transition was defined for plain files
and directories. With this update, also socket files are a subject of
the same transition.