### PR TITLE
Release 1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,9 @@ semodule -r pulpcore_rhsmcertd
 semodule -r pulpcore
 semodule -r pulpcore_port
 ```
+
+# Development
+
+## Release Process
+
+See the [Release Guide](RELEASING.md)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,8 @@
+Release Guide
+=============
+
+1. Bump the version number (`sed -i -e 's/1.2.1/1.2.2/g' *.te`).
+1. Create a PR with all the changes above and merge it after a review.
+1. Create a release on github. It will create the corresponding tag.
+1. In that release, copy and paste the git commit titles since the last release
+(`git shortlog 1.2.1...master --no-merges | grep -E "^(\s)+\w" | sed -e 's/     /*/'`)

--- a/pulpcore.te
+++ b/pulpcore.te
@@ -1,4 +1,4 @@
-policy_module(pulpcore, 1.2.0)
+policy_module(pulpcore, 1.2.2)
 
 ########################################
 #

--- a/pulpcore_port.te
+++ b/pulpcore_port.te
@@ -1,4 +1,4 @@
-policy_module(pulpcore_port, 1.2.0)
+policy_module(pulpcore_port, 1.2.2)
 
 gen_require(`
     attribute port_type;

--- a/pulpcore_rhsmcertd.te
+++ b/pulpcore_rhsmcertd.te
@@ -1,4 +1,4 @@
-policy_module(pulpcore_rhsmcertd, 1.2.0)
+policy_module(pulpcore_rhsmcertd, 1.2.2)
 
 gen_require(`
 	type pulpcore_server_t, rhsmcertd_config_t;


### PR DESCRIPTION
I deleted the 1.2.1 release, but left the tag there.

The problem with it is that I forgot to bump the version string.

when I release 1.2.2, I'll do the changelog since 1.2.0.