### PR TITLE
Allow systemd Type=notify and label /run/pulpcore-(api|content).sock

### DIFF
--- a/pulpcore.fc
+++ b/pulpcore.fc
@@ -24,4 +24,5 @@
 
 /var/run/pulpcore-api(/.*)?		gen_context(system_u:object_r:pulpcore_server_var_run_t,s0)
 /var/run/pulpcore-content(/.*)?		gen_context(system_u:object_r:pulpcore_server_var_run_t,s0)
+/var/run/pulpcore-(api|content)\.sock	gen_context(system_u:object_r:pulpcore_server_var_run_t,s0)
 /var/run/pulpcore.*			gen_context(system_u:object_r:pulpcore_var_run_t,s0)

--- a/pulpcore.te
+++ b/pulpcore.te
@@ -127,6 +127,9 @@ fs_getattr_xattr_fs(pulpcore_server_t)
 libs_exec_ldconfig(pulpcore_t)
 libs_exec_ldconfig(pulpcore_server_t)
 
+# Needed for systemd Type=notify support
+init_write_pid_socket(pulpcore_server_t)
+
 miscfiles_read_generic_certs(pulpcore_t)
 
 sysnet_read_config(pulpcore_t)


### PR DESCRIPTION
When Type=notify is used, it will open a unix socket (typically /run/systemd/notify). Prior to this, it was rejected. The result was that the service never really started and systemd ended up killing the service after some time.

Currently untested, hence a draft. Pushing it here for collaboration.