### PR TITLE
Label all of /var/lib/pulp as pulpcore_var_lib_t

### DIFF
--- a/pulpcore.fc
+++ b/pulpcore.fc
@@ -14,13 +14,8 @@
 /usr/local/lib/pulp/bin/gunicorn	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
 /usr/local/lib/pulp/bin/rq		--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
 
-/var/lib/pulp/(media|artifact)(/.*)?	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
-/var/lib/pulp/assets(/.*)?	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
-/var/lib/pulp/devel(/.*)?	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
+/var/lib/pulp(/.*)?	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
 /var/lib/pulp/pulpcore_static(/.*)? 	gen_context(system_u:object_r:httpd_sys_content_t,s0)
-/var/lib/pulp/tmp(/.*)?		gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
-/var/lib/pulp/upload(/.*)?	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
-/var/lib/pulp/sign-metadata.sh	--	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
 
 /var/run/pulpcore-api(/.*)?		gen_context(system_u:object_r:pulpcore_server_var_run_t,s0)
 /var/run/pulpcore-content(/.*)?		gen_context(system_u:object_r:pulpcore_server_var_run_t,s0)


### PR DESCRIPTION
Previously this wasn't done because Pulp 2 already defined this. However, at this point compatibility with Pulp 2 is no longer needed. This simplifies the policy.

Another benefit is Katello defines /var/lib/pulp/export as an export location. That means it also needs a pulpcore_var_lib_t label, which this change ensures.