### PR TITLE
Update for systemd type=notify, /etc/apache/ access, and release 1.2.5

### DIFF
--- a/pulpcore.te
+++ b/pulpcore.te
@@ -1,5 +1,10 @@
 policy_module(pulpcore, 1.2.4)
 
+require {
+	type httpd_config_t;
+	class dir search;
+}
+
 ########################################
 #
 # Declarations
@@ -140,6 +145,10 @@ allow kernel_t init_var_run_t:unix_dgram_socket sendto;
 miscfiles_read_generic_certs(pulpcore_t)
 
 sysnet_read_config(pulpcore_t)
+
+# Attempts to read the non-existent /etc/httpd/mime.types with Katello on EL7
+# Occurs whenever mailcap isn't installed, which would provide /etc/mime.types
+dontaudit pulpcore_server_t httpd_config_t:dir search;
 
 optional_policy(`
         gpg_exec(pulpcore_t)

--- a/pulpcore.te
+++ b/pulpcore.te
@@ -1,4 +1,4 @@
-policy_module(pulpcore, 1.2.4)
+policy_module(pulpcore, 1.2.5)
 
 require {
 	type httpd_config_t;

--- a/pulpcore.te
+++ b/pulpcore.te
@@ -98,6 +98,10 @@ fs_tmpfs_filetrans(pulpcore_t, pulpcore_server_tmpfs_t, file )
 allow pulpcore_t pulpcore_server_tmpfs_t:file map;
 
 # interface calls
+
+# Needed for systemd Type=notify support
+kernel_dgram_send(pulpcore_server_t)
+
 kernel_read_all_proc(pulpcore_t)
 kernel_read_all_proc(pulpcore_server_t)
 
@@ -129,6 +133,9 @@ libs_exec_ldconfig(pulpcore_server_t)
 
 # Needed for systemd Type=notify support
 init_write_pid_socket(pulpcore_server_t)
+allow pulpcore_server_t init_var_run_t:unix_dgram_socket { connect create };
+allow pulpcore_server_t self:unix_dgram_socket { connect create };
+allow kernel_t init_var_run_t:unix_dgram_socket sendto;
 
 miscfiles_read_generic_certs(pulpcore_t)
 

--- a/pulpcore_port.te
+++ b/pulpcore_port.te
@@ -1,4 +1,4 @@
-policy_module(pulpcore_port, 1.2.4)
+policy_module(pulpcore_port, 1.2.5)
 
 gen_require(`
     attribute port_type;

--- a/pulpcore_rhsmcertd.te
+++ b/pulpcore_rhsmcertd.te
@@ -1,4 +1,4 @@
-policy_module(pulpcore_rhsmcertd, 1.2.4)
+policy_module(pulpcore_rhsmcertd, 1.2.5)
 
 gen_require(`
 	type pulpcore_server_t, rhsmcertd_config_t;


### PR DESCRIPTION
fixes: #9272
pulpcore-selinux needs SELinux changes for systemd Type=notify
https://pulp.plan.io/issues/9272
https://bugzilla.redhat.com/show_bug.cgi?id=1976783#
https://community.theforeman.org/t/katello-pulpcore-selinux-issues/24507

related to: #9271
gunicorn processes should be managed by systemd as Type=notify
https://pulp.plan.io/issues/9271