### PR TITLE
Set file contexts for all of /var/lib/pulp

### DIFF
--- a/pulpcore.fc
+++ b/pulpcore.fc
@@ -15,13 +15,8 @@
 # Old tasking system.
 /usr/local/lib/pulp/bin/rq		--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
 
-/var/lib/pulp/(media|artifact)(/.*)?	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
-/var/lib/pulp/assets(/.*)?	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
-/var/lib/pulp/devel(/.*)?	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
+/var/lib/pulp(/.*)?			gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
 /var/lib/pulp/pulpcore_static(/.*)? 	gen_context(system_u:object_r:httpd_sys_content_t,s0)
-/var/lib/pulp/tmp(/.*)?		gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
-/var/lib/pulp/upload(/.*)?	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
-/var/lib/pulp/sign-metadata.sh	--	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)
 
 # galaxy-importer
 /var/lib/pulp/.ansible(/.*)?	gen_context(system_u:object_r:pulpcore_var_lib_t,s0)


### PR DESCRIPTION
This wasn't done in the past to coexist with pulp-selinux (from Pulp 2), but those days are long gone. This also makes it easy to set the correct label on /var/lib/pulp/exports (as Katello does).

I think this addresses https://bugzilla.redhat.com/show_bug.cgi?id=2172833