### PR TITLE
Release 2.0.0

### DIFF
--- a/pulpcore.te
+++ b/pulpcore.te
@@ -1,4 +1,4 @@
-policy_module(pulpcore, 1.3.3)
+policy_module(pulpcore, 2.0.0)
 
 require {
 	type httpd_config_t;

--- a/pulpcore_port.te
+++ b/pulpcore_port.te
@@ -1,4 +1,4 @@
-policy_module(pulpcore_port, 1.3.3)
+policy_module(pulpcore_port, 2.0.0)
 
 gen_require(`
     attribute port_type;

--- a/pulpcore_rhsmcertd.te
+++ b/pulpcore_rhsmcertd.te
@@ -1,4 +1,4 @@
-policy_module(pulpcore_rhsmcertd, 1.3.3)
+policy_module(pulpcore_rhsmcertd, 2.0.0)
 
 gen_require(`
 	type pulpcore_server_t, rhsmcertd_config_t;


### PR DESCRIPTION
CHANGELOG:
* Set file contexts for all of /var/lib/pulp
* Note: The above removes the ability to exist alongside Pulp 2.