### PR TITLE
correctly label pulpcore-(api|content) binaries

### DIFF
--- a/pulpcore.fc
+++ b/pulpcore.fc
@@ -7,6 +7,9 @@
 /etc/pulp/certs/token_public_key.pem		gen_context(system_u:object_r:pulpcore_etc_t,s0)
 /etc/pulp/settings.py			gen_context(system_u:object_r:pulpcore_etc_t,s0)
 
+/usr/bin/pulpcore-(api|content)	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
+/usr/bin/pulpcore-worker	--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
+
 /usr/libexec/pulpcore/.*	--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
 /usr/libexec/pulpcore/gunicorn	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
 


### PR DESCRIPTION
since pulpcore 3.33 there are new binaries to start pulpcore services, but those binaries were not properly labeled with pulpcore_server_exec_t like their old counterpart gunicorn
without that label, the services run as unconfined_service_t, which results in errors like httpd not being able to connect to them

while at it, also properly label the pulpcore-worker binary in /usr/bin