### PR TITLE
Simplify build instructions by providing a Makefile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,4 @@ jobs:
         run: yum install -y selinux-policy-devel policycoreutils
       - name: Build policies
         run: |
-          make -f /usr/share/selinux/devel/Makefile pulpcore_port.pp
-          make -f /usr/share/selinux/devel/Makefile pulpcore.pp
-          make -f /usr/share/selinux/devel/Makefile pulpcore_rhsmcertd.pp
+          make build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pp
+pulpcore_port.fc
+pulpcore_port.if
+pulpcore_rhsmcertd.fc
+pulpcore_rhsmcertd.if

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
+include /usr/share/selinux/devel/Makefile
+
+build: pulpcore_port.pp pulpcore.pp pulpcore_rhsmcertd.pp ## Build SELinux policies
+
 help: ## Show this help.
-	@sed -ne '/@sed/!s/## //p' $(MAKEFILE_LIST)
+	@sed -ne '/@sed/!s/:.\+## /: /p' $(firstword $(MAKEFILE_LIST))
 
 docs: ## Build unified docs.
 	pulp-docs build
@@ -7,4 +11,4 @@ docs: ## Build unified docs.
 servedocs: ## Serves unified docs.
 	pulp-docs serve
 
-.PHONY: docs servedocs help
+.PHONY: build docs servedocs help

--- a/docs/admin/index.md
+++ b/docs/admin/index.md
@@ -10,10 +10,7 @@ The SELinux policy for Pulp 3.Y releases.
 sudo yum install -y selinux-policy-devel policycoreutils
 git clone https://github.com/pulp/pulpcore-selinux
 cd pulpcore-selinux
-
-make -f /usr/share/selinux/devel/Makefile pulpcore_port.pp
-make -f /usr/share/selinux/devel/Makefile pulpcore.pp
-make -f /usr/share/selinux/devel/Makefile pulpcore_rhsmcertd.pp
+make build
 ```
 
 ### Installing


### PR DESCRIPTION
This creates a gitignore file to deal with generated files. The Makefile replaces the manual instructions and makes sure CI and user instructions are in sync. It even allows for parallel builds, even though the building is already super fast.