### PR TITLE
Correctly label pulpcore-(api|content) binaries in a venv

### DIFF
--- a/pulpcore.fc
+++ b/pulpcore.fc
@@ -14,6 +14,7 @@
 /usr/libexec/pulpcore/gunicorn	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
 
 /usr/local/lib/pulp/bin/gunicorn	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
+/usr/local/lib/pulp/bin/pulpcore-(api|content)	--	gen_context(system_u:object_r:pulpcore_server_exec_t,s0)
 /usr/local/lib/pulp/bin/pulpcore-worker	--	gen_context(system_u:object_r:pulpcore_exec_t,s0)
 # Old tasking system.
 /usr/local/lib/pulp/bin/rq		--	gen_context(system_u:object_r:pulpcore_exec_t,s0)


### PR DESCRIPTION
Apply the similar labels to venv installed pulp binaries as those directly in /usr/bin/.

Basically f57c41f32cc9ff8e34120bd3807805002256db23 with venv path.