### PR TITLE
Drop EL7 & EL8 testing in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     container:
       image: ${{ matrix.centos }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install packages
         run: yum install -y selinux-policy-devel policycoreutils
       - name: Build policies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        centos: ["centos:7", "quay.io/centos/centos:stream8", "quay.io/centos/centos:stream9"]
+        centos:
+          - "quay.io/centos/centos:stream9"
     container:
       image: ${{ matrix.centos }}
     steps:


### PR DESCRIPTION
Both CentOS 7 and 8 are EOL and no longer available on the mirrors. Foreman has also dropped EL8 support so doesn't have a need for it anymore. The alternative was to add AlmaLinux 8.