### PR TITLE
Allow aiodns/pycares to watch /etc directory for resolver configuration changes

### DIFF
--- a/pulpcore.te
+++ b/pulpcore.te
@@ -2,7 +2,6 @@ policy_module(pulpcore, 2.1.0)
 
 require {
 	type httpd_config_t;
-	type etc_t;
 	class dir search;
 }
 


### PR DESCRIPTION
This change fixes SELinux AVC denials that occur when upgrading pulpcore from 3.73.15 to 3.85.1. The pulpcore-worker process now monitors the /etc directory for configuration file changes using inotify.

The AVC denial was:
avc: denied { watch } for pid=... comm="pulpcore-worker" path="/etc" scontext=system_u:system_r:pulpcore_t:s0 tcontext=system_u:object_r:etc_t:s0

Changes:
- Add etc_t type to require section
- Allow pulpcore_t domain to watch etc_t directories

This is a minimal and targeted fix that only grants the specific watch permission needed for configuration file monitoring.